### PR TITLE
Decrease default cleanup history limit to 1

### DIFF
--- a/helm/multi-juicer/templates/cleanup-chron-job.yaml
+++ b/helm/multi-juicer/templates/cleanup-chron-job.yaml
@@ -5,8 +5,8 @@ metadata:
   name: 'cleanup-job'
 spec:
   schedule: {{ .Values.juiceShopCleanup.cron }}
-  successfulJobsHistoryLimit: 10
-  failedJobsHistoryLimit: 10
+  successfulJobsHistoryLimit: {{ .Values.juiceShopCleanup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.juiceShopCleanup.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
       template:

--- a/helm/multi-juicer/values.yaml
+++ b/helm/multi-juicer/values.yaml
@@ -75,6 +75,8 @@ juiceShopCleanup:
   # defaults to once in an hour
   # change this if your grace period if shorter than 1 hour
   cron: '0 * * * *'
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
   resources:
     requests:
       memory: 256Mi


### PR DESCRIPTION
This ensures that low resource clusters are not blocked by completed cleanup jobs blocking the resources.

Closes #35