### PR TITLE
Pin JuiceShop Version to avoid incompatabilities with v10

### DIFF
--- a/helm/multi-juicer/values.yaml
+++ b/helm/multi-juicer/values.yaml
@@ -9,7 +9,7 @@ balancer:
     # If secure is set to true the cookie name will automatically be prefixed with "__Secure-"
     name: balancer
   repository: iteratec/juice-balancer
-  tag: latest
+  tag: v9.3.1
   replicas: 1
   resources:
     requests:


### PR DESCRIPTION
JuiceShop v10 changed their config structure which breaks the default config provider by MultiJuicer.
To avoid these problems this Pull Request pins the JuiceShop version to the latest 9.x version.

MultiJuicer will update the default JuiceShop version used with release 3.0.0 to JuiceShop 10.x