### PR TITLE
Prevent accidental overwrite of "ctf" config section with null

### DIFF
--- a/helm/multi-juicer/values.yaml
+++ b/helm/multi-juicer/values.yaml
@@ -100,7 +100,7 @@ juiceShop:
       showVersionNumber: false
       # showHackingInstructor: false
       showGitHubLinks: false
-    ctf:
+    # ctf:
       # showFlagsInNotifications: true
   # Specify a custom NODE_ENV for JuiceShop.
   # If value is changed to something other than 'multi-juicer' it's not possible to set a custom config.


### PR DESCRIPTION
(fixes iteratec/multi-juicer#52)