### PR TITLE
Add button to reset passcode

### DIFF
--- a/juice-balancer/src/__mocks__/kubernetes.js
+++ b/juice-balancer/src/__mocks__/kubernetes.js
@@ -8,4 +8,5 @@ module.exports = {
   getJuiceShopInstances: jest.fn(),
   deletePodForTeam: jest.fn(),
   updateLastRequestTimestampForTeam: jest.fn(),
+  changePasscodeHashForTeam: jest.fn(),
 };

--- a/juice-balancer/src/kubernetes.js
+++ b/juice-balancer/src/kubernetes.js
@@ -262,3 +262,26 @@ const updateLastRequestTimestampForTeam = (teamname) => {
   );
 };
 module.exports.updateLastRequestTimestampForTeam = updateLastRequestTimestampForTeam;
+
+const changePasscodeHashForTeam = async (teamname, passcodeHash) => {
+  const headers = { 'content-type': 'application/strategic-merge-patch+json' };
+  const deploymentPatch = {
+    metadata: {
+      annotations: {
+        'multi-juicer.iteratec.dev/passcode': passcodeHash,
+      },
+    },
+  };
+
+  await k8sAppsApi.patchNamespacedDeployment(
+    `${teamname}-juiceshop`,
+    get('namespace'),
+    deploymentPatch,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    { headers }
+  );
+};
+module.exports.changePasscodeHashForTeam = changePasscodeHashForTeam;

--- a/juice-balancer/src/teams/teams.js
+++ b/juice-balancer/src/teams/teams.js
@@ -15,6 +15,7 @@ const {
   createServiceForTeam,
   getJuiceShopInstanceForTeamname,
   getJuiceShopInstances,
+  changePasscodeHashForTeam,
 } = require('../kubernetes');
 
 const loginCounter = new promClient.Counter({
@@ -208,10 +209,10 @@ async function resetPasscode(req, res) {
 
   logger.info(`Resetting passcode for team ${team}`);
 
-  const { passcode } = generatePasscode();
+  const { passcode, hash } = generatePasscode();
 
   try {
-    // TODO: change passcode hash in deployment
+    await changePasscodeHashForTeam(req.teamname, hash);
 
     return res.status(200).json({
       message: 'Reset Passcode',

--- a/juice-balancer/src/teams/teams.js
+++ b/juice-balancer/src/teams/teams.js
@@ -203,7 +203,9 @@ async function resetPasscode(req, res) {
     return res.status(401).send({ message: 'A cookie needs to be set to reset the passcode' });
   }
 
-  // TODO: Check admin requests
+  if (req.cleanedTeamname === get('admin.username')) {
+    return res.status(403).send({ message: 'The admin is not allowed to reset the passcode' });
+  }
 
   const team = req.cleanedTeamname;
 

--- a/juice-balancer/src/teams/teams.js
+++ b/juice-balancer/src/teams/teams.js
@@ -154,9 +154,9 @@ async function checkIfMaxJuiceShopInstancesIsReached(req, res, next) {
   }
 }
 
-function generatePasscode() {
+async function generatePasscode() {
   const passcode = cryptoRandomString({ length: 8 }).toUpperCase();
-  const hash = bcrypt.hashSync(passcode, BCRYPT_ROUNDS);
+  const hash = await bcrypt.hash(passcode, BCRYPT_ROUNDS);
   return { passcode, hash };
 }
 
@@ -167,7 +167,7 @@ function generatePasscode() {
 async function createTeam(req, res) {
   const { team } = req.params;
   try {
-    const { passcode, hash } = generatePasscode();
+    const { passcode, hash } = await generatePasscode();
 
     logger.info(`Creating JuiceShop Deployment for team "${team}"`);
 
@@ -211,7 +211,7 @@ async function resetPasscode(req, res) {
 
   logger.info(`Resetting passcode for team ${team}`);
 
-  const { passcode, hash } = generatePasscode();
+  const { passcode, hash } = await generatePasscode();
 
   try {
     await changePasscodeHashForTeam(req.teamname, hash);

--- a/juice-balancer/src/teams/teams.js
+++ b/juice-balancer/src/teams/teams.js
@@ -153,6 +153,12 @@ async function checkIfMaxJuiceShopInstancesIsReached(req, res, next) {
   }
 }
 
+function generatePasscode() {
+  const passcode = cryptoRandomString({ length: 8 }).toUpperCase();
+  const hash = bcrypt.hashSync(passcode, BCRYPT_ROUNDS);
+  return { passcode, hash };
+}
+
 /**
  * @param {import("express").Request} req
  * @param {import("express").Response} res
@@ -160,8 +166,7 @@ async function checkIfMaxJuiceShopInstancesIsReached(req, res, next) {
 async function createTeam(req, res) {
   const { team } = req.params;
   try {
-    const passcode = cryptoRandomString({ length: 8 }).toUpperCase();
-    const hash = await bcrypt.hash(passcode, BCRYPT_ROUNDS);
+    const { passcode, hash } = generatePasscode();
 
     logger.info(`Creating JuiceShop Deployment for team "${team}"`);
 
@@ -203,8 +208,7 @@ async function resetPasscode(req, res) {
 
   logger.info(`Resetting passcode for team ${team}`);
 
-  const passcode = cryptoRandomString({ length: 8 }).toUpperCase();
-  // const hash = bcrypt.hashSync(passcode, BCRYPT_ROUNDS);
+  const { passcode } = generatePasscode();
 
   try {
     // TODO: change passcode hash in deployment

--- a/juice-balancer/src/teams/teams.js
+++ b/juice-balancer/src/teams/teams.js
@@ -75,7 +75,7 @@ async function interceptAdminLogin(req, res, next) {
  * @param {import("express").Response} res
  * @param {import("express").NextFunction} next
  */
-async function checkIfTeamAlreadyExists(req, res, next) {
+async function joinIfTeamAlreadyExists(req, res, next) {
   const { team } = req.params;
   const { passcode } = req.body;
 
@@ -249,7 +249,7 @@ router.post(
   validator.params(paramsSchema),
   validator.body(bodySchema),
   interceptAdminLogin,
-  checkIfTeamAlreadyExists,
+  joinIfTeamAlreadyExists,
   checkIfMaxJuiceShopInstancesIsReached,
   createTeam
 );

--- a/juice-balancer/src/teams/teams.test.js
+++ b/juice-balancer/src/teams/teams.test.js
@@ -11,15 +11,9 @@ const {
   createServiceForTeam,
 } = require('../kubernetes');
 
-afterAll(async () => {
-  await new Promise((resolve) => setTimeout(() => resolve(), 500)); // avoid jest open handle error
-});
-
-beforeEach(() => {
-  getJuiceShopInstanceForTeamname.mockClear();
-  getJuiceShopInstances.mockImplementation(async () => {
-    return { body: { items: [] } };
-  });
+afterEach(() => {
+  getJuiceShopInstanceForTeamname.mockReset();
+  getJuiceShopInstances.mockReset();
 });
 
 describe('teamname validation', () => {

--- a/juice-balancer/src/teams/teams.test.js
+++ b/juice-balancer/src/teams/teams.test.js
@@ -4,6 +4,7 @@ jest.mock('http-proxy');
 const request = require('supertest');
 const bcrypt = require('bcryptjs');
 const app = require('../app');
+const { get } = require('../config');
 const {
   getJuiceShopInstanceForTeamname,
   getJuiceShopInstances,
@@ -146,6 +147,14 @@ test('reset passcode needs authentication if no cookie is sent', async () => {
   await request(app).post('/balancer/teams/reset-passcode').send().expect(401);
 });
 
+test('reset passcode is forbidden for admin', async () => {
+  await request(app)
+    .post('/balancer/teams/reset-passcode')
+    .set('Cookie', [`${get('cookieParser.cookieName')}=t-${get('admin.username')}`])
+    .send()
+    .expect(403);
+});
+
 test('reset passcode fails with not found if team does not exist', async () => {
   const team = 't-test-team';
 
@@ -155,7 +164,7 @@ test('reset passcode fails with not found if team does not exist', async () => {
 
   await request(app)
     .post(`/balancer/teams/reset-passcode`)
-    .set('Cookie', [`balancer=${team}`])
+    .set('Cookie', [`${get('cookieParser.cookieName')}=${team}`])
     .send()
     .expect(404);
 });
@@ -167,7 +176,7 @@ test('reset passcode resets passcode to new value if team exists', async () => {
 
   await request(app)
     .post(`/balancer/teams/reset-passcode`)
-    .set('Cookie', [`balancer=${team}`])
+    .set('Cookie', [`${get('cookieParser.cookieName')}=${team}`])
     .send()
     .expect(200)
     .then(({ body }) => {

--- a/juice-balancer/ui/src/Components.js
+++ b/juice-balancer/ui/src/Components.js
@@ -58,7 +58,7 @@ export const Button = styled.button`
 `;
 
 export const SecondaryButton = styled(Button)`
-  margin: 0;
+  margin: 0 0 0 5px;
   width: auto;
   background-color: #d8d8d8;
   color: #232323;

--- a/juice-balancer/ui/src/cards/PassCodeDisplayCard.js
+++ b/juice-balancer/ui/src/cards/PassCodeDisplayCard.js
@@ -10,7 +10,7 @@ const CharDisplay = styled.span`
   background-color: #d8d8d8;
   border-radius: 4px;
   margin-right: 8px;
-  margin-left: ${props => (props.addOffset ? '8px' : '0')};
+  margin-left: ${(props) => (props.addOffset ? '8px' : '0')};
   display: inline-block;
 `;
 
@@ -35,12 +35,18 @@ const CenteredContent = styled.div`
   margin-top: 16px;
 `;
 
-export const PasscodeDisplayCard = ({ passcode = '' }) => {
+const PasscodeTitle = ({ reset }) => {
+  if (reset) {
+    return <H2><FormattedMessage id="passcode_reset" defaultMessage="Passcode Reset" /></H2>;
+  } else {
+    return <H2><FormattedMessage id="team_created" defaultMessage="Team Created" /></H2>;
+  }
+}
+
+export const PasscodeDisplayCard = ({ passcode = '', reset = false }) => {
   return (
     <BodyCard>
-      <H2>
-        <FormattedMessage id="team_created" defaultMessage="Team Created" />
-      </H2>
+      <PasscodeTitle reset={reset}/>
       <p>
         <FormattedMessage
           id="passcode_explanation"

--- a/juice-balancer/ui/src/cards/TeamDisplayCard.js
+++ b/juice-balancer/ui/src/cards/TeamDisplayCard.js
@@ -47,6 +47,21 @@ const LogoutButton = withRouter(({ history }) => {
   );
 });
 
+const PasscodeResetButton = withRouter(({ history, teamname }) => {
+  async function resetPasscode() {
+    await axios.post('/balancer/teams/reset-passcode')
+      .then(({ data }) => {
+          history.push(`/teams/${teamname}/joined/`, { passcode: data.passcode, reset: true })
+      });
+  }
+
+  return (
+    <SecondaryButton onClick={resetPasscode}>
+      <FormattedMessage id="reset_passcode" defaultMessage="Reset Passcode" />
+    </SecondaryButton>
+  );
+});
+
 export const TeamDisplayCard = ({ teamname }) => {
   return (
     <TeamDisplayCardWrapper>
@@ -58,6 +73,7 @@ export const TeamDisplayCard = ({ teamname }) => {
         <H3>{teamname}</H3>
       </TeamDisplayTextWrapper>
       <LogoutButton />
+      <PasscodeResetButton teamname={teamname} />
     </TeamDisplayCardWrapper>
   );
 };

--- a/juice-balancer/ui/src/pages/JoinedPage.js
+++ b/juice-balancer/ui/src/pages/JoinedPage.js
@@ -11,8 +11,8 @@ export const JoinedPage = withRouter(({ location, match }) => {
   return (
     <>
       <TeamDisplayCard teamname={team} />
-      {location.state !== undefined ? (
-        <PasscodeDisplayCard passcode={location.state.passcode} />
+      {location.state?.passcode !== undefined ? (
+        <PasscodeDisplayCard passcode={location.state.passcode} reset={location.state.reset} />
       ) : null}
       <InstanceStatusCard teamname={team} />
     </>

--- a/juice-balancer/ui/src/translations/de-DE.js
+++ b/juice-balancer/ui/src/translations/de-DE.js
@@ -15,7 +15,9 @@ export default {
   join_team: 'Team Beitreten',
   logged_in_as: 'Eingelogged als',
   log_out: 'Ausloggen',
+  reset_passcode: 'Passwort Zurücksetzen',
   team_created: 'Team Erstellt',
+  passcode_reset: 'Passwort Zurückgesetzt',
   passcode_explanation:
     'Um sicherzustellen das nicht jeder einfach deinem Team beitreten kann, haben wir ein Passwort erstellt das du mit deinem Teammitgliedern teilen kannst. Deine Teammitglieder brauchen das gleiche Passwort um dem Team beizutreten. Du kannst das Passwort von unten kopieren.',
   passcode: 'Passwort',


### PR DESCRIPTION
I did some work on #63:
The PR adds a new button to the `<TeamDisplayCard />`.

Clicking it will generate a new passcode, patch the teams juice-shop deployment with the new hash and return the passcode to the user. The passcode will then be displayed via the old but modified `<PasscodeDisplayCard />`.

Looking forward to your feedback!

<img width="801" alt="Screenshot 2020-10-08 at 15 40 56" src="https://user-images.githubusercontent.com/12832754/95476433-887c1400-0987-11eb-8fe9-8ae1ae43401c.png">
