### PR TITLE
Caching fix

### DIFF
--- a/juice-balancer/src/kubernetes.js
+++ b/juice-balancer/src/kubernetes.js
@@ -244,7 +244,7 @@ module.exports.getJuiceShopInstanceForTeamname = getJuiceShopInstanceForTeamname
 const updateLastRequestTimestampForTeam = (teamname) => {
   const headers = { 'content-type': 'application/strategic-merge-patch+json' };
   return k8sAppsApi.patchNamespacedDeployment(
-    `${teamname}-juiceshop`,
+    `t-${teamname}-juiceshop`,
     get('namespace'),
     {
       metadata: {

--- a/juice-balancer/src/proxy/proxy.js
+++ b/juice-balancer/src/proxy/proxy.js
@@ -77,7 +77,7 @@ async function checkIfInstanceIsUp(req, res, next) {
  */
 async function updateLastConnectTimestamp(req, res, next) {
   const currentTime = new Date().getTime();
-  const teamname = req.teamname;
+  const teamname = req.cleanedTeamname;
 
   try {
     if (connectionCache.has(teamname)) {
@@ -88,7 +88,6 @@ async function updateLastConnectTimestamp(req, res, next) {
       }
     } else {
       await updateLastRequestTimestampForTeam(teamname);
-
       connectionCache.set(teamname, currentTime);
     }
   } catch (error) {

--- a/juice-balancer/src/proxy/proxy.test.js
+++ b/juice-balancer/src/proxy/proxy.test.js
@@ -82,7 +82,7 @@ test('should update the last-connect timestamp on requests at most every 10sec',
     .expect('proxied');
 
   expect(updateLastRequestTimestampForTeam).not.toHaveBeenCalled();
- 
+
   // Wait for >10s
   advanceBy(10 * 1000 + 1);
 
@@ -103,32 +103,32 @@ test('should only call getJuiceShopInstanceForTeamname on requests at most every
     .get('/rest/admin/application-version')
     .set('Cookie', ['balancer=t-team-get-instance-test'])
     .send()
+    .expect(200);
+
+  expect(getJuiceShopInstanceForTeamname).toHaveBeenCalled();
+
+  getJuiceShopInstanceForTeamname.mockClear();
+
+  await request(app)
+    .get('/rest/admin/application-version')
+    .set('Cookie', ['balancer=t-team-get-instance-test'])
+    .send()
     .expect(200)
-   
-    expect(getJuiceShopInstanceForTeamname).toHaveBeenCalled();
+    .expect('proxied');
 
-    getJuiceShopInstanceForTeamname.mockClear();
+  expect(getJuiceShopInstanceForTeamname).not.toHaveBeenCalled();
 
-    await request(app)
-      .get('/rest/admin/application-version')
-      .set('Cookie', ['balancer=t-team-get-instance-test'])
-      .send()
-      .expect(200)
-      .expect('proxied');
-  
-    expect(getJuiceShopInstanceForTeamname).not.toHaveBeenCalled();
-   
-    // Wait for >10s
-    advanceBy(10 * 1000 + 1);
-  
-    await request(app)
-      .get('/rest/admin/application-version')
-      .set('Cookie', ['balancer=t-team-get-instance-test'])
-      .send()
-      .expect(200)
-      .expect('proxied');
-  
-    expect(getJuiceShopInstanceForTeamname).toHaveBeenCalled();
+  // Wait for >10s
+  advanceBy(10 * 1000 + 1);
+
+  await request(app)
+    .get('/rest/admin/application-version')
+    .set('Cookie', ['balancer=t-team-get-instance-test'])
+    .send()
+    .expect(200)
+    .expect('proxied');
+
+  expect(getJuiceShopInstanceForTeamname).toHaveBeenCalled();
 });
 
 test('should redirect to /balancer/ when the instance is currently restarting', async () => {

--- a/juice-balancer/src/proxy/proxy.test.js
+++ b/juice-balancer/src/proxy/proxy.test.js
@@ -57,7 +57,7 @@ test('should set the last-connect timestamp when a new team gets proxied the fir
     .expect(200)
     .expect('proxied');
 
-  expect(updateLastRequestTimestampForTeam).toHaveBeenCalledWith('t-team-last-connect-test');
+  expect(updateLastRequestTimestampForTeam).toHaveBeenCalledWith('team-last-connect-test');
 });
 
 test('should update the last-connect timestamp on requests at most every 10sec', async () => {
@@ -70,7 +70,7 @@ test('should update the last-connect timestamp on requests at most every 10sec',
     .expect(200)
     .expect('proxied');
 
-  expect(updateLastRequestTimestampForTeam).toHaveBeenCalledWith('t-team-update-last-connect-test');
+  expect(updateLastRequestTimestampForTeam).toHaveBeenCalledWith('team-update-last-connect-test');
 
   updateLastRequestTimestampForTeam.mockClear();
 
@@ -82,7 +82,7 @@ test('should update the last-connect timestamp on requests at most every 10sec',
     .expect('proxied');
 
   expect(updateLastRequestTimestampForTeam).not.toHaveBeenCalled();
-
+ 
   // Wait for >10s
   advanceBy(10 * 1000 + 1);
 
@@ -93,7 +93,42 @@ test('should update the last-connect timestamp on requests at most every 10sec',
     .expect(200)
     .expect('proxied');
 
-  expect(updateLastRequestTimestampForTeam).toHaveBeenCalledWith('t-team-update-last-connect-test');
+  expect(updateLastRequestTimestampForTeam).toHaveBeenCalledWith('team-update-last-connect-test');
+});
+
+test('should only call getJuiceShopInstanceForTeamname on requests at most every 10sec', async () => {
+  advanceTo(new Date(1000000000000));
+
+  await request(app)
+    .get('/rest/admin/application-version')
+    .set('Cookie', ['balancer=t-team-get-instance-test'])
+    .send()
+    .expect(200)
+   
+    expect(getJuiceShopInstanceForTeamname).toHaveBeenCalled();
+
+    getJuiceShopInstanceForTeamname.mockClear();
+
+    await request(app)
+      .get('/rest/admin/application-version')
+      .set('Cookie', ['balancer=t-team-get-instance-test'])
+      .send()
+      .expect(200)
+      .expect('proxied');
+  
+    expect(getJuiceShopInstanceForTeamname).not.toHaveBeenCalled();
+   
+    // Wait for >10s
+    advanceBy(10 * 1000 + 1);
+  
+    await request(app)
+      .get('/rest/admin/application-version')
+      .set('Cookie', ['balancer=t-team-get-instance-test'])
+      .send()
+      .expect(200)
+      .expect('proxied');
+  
+    expect(getJuiceShopInstanceForTeamname).toHaveBeenCalled();
 });
 
 test('should redirect to /balancer/ when the instance is currently restarting', async () => {


### PR DESCRIPTION
Updated teamname in updateLastConnectTimestamp so that it is consistent with checkIfInstanceIsUp teamname. Also updated updateLastRequestTimestampForTeam to add 't-' to teamname for consistancy. Updated proxy tests and added new test to check for getJuiceShopInstanceForTeamname being called on every request.