### PR TITLE
Adding HelmChart configuration for ENV, Volume and VolumeMounts

### DIFF
--- a/helm/multi-juicer/templates/juice-balancer-config-map.yaml
+++ b/helm/multi-juicer/templates/juice-balancer-config-map.yaml
@@ -32,5 +32,9 @@ data:
         "nodeEnv": {{ .Values.juiceShop.nodeEnv | quote }},
         "resources": {{ .Values.juiceShop.resources | toJson }},
         "securityContext": {{ .Values.juiceShop.securityContext | toJson }}
+        "env": {{ .Values.juiceShop.env | toJson }},
+        "envFrom": {{ .Values.juiceShop.envFrom | toJson }}
+        "volumes": {{ .Values.juiceShop.volumes | toJson }}
+        "volumeMounts": {{ .Values.juiceShop.volumeMounts | toJson }}
       }
     }

--- a/helm/multi-juicer/templates/juice-balancer-config-map.yaml
+++ b/helm/multi-juicer/templates/juice-balancer-config-map.yaml
@@ -31,10 +31,10 @@ data:
         "ctfKey": {{ .Values.juiceShop.ctfKey | quote }},
         "nodeEnv": {{ .Values.juiceShop.nodeEnv | quote }},
         "resources": {{ .Values.juiceShop.resources | toJson }},
-        "securityContext": {{ .Values.juiceShop.securityContext | toJson }}
+        "securityContext": {{ .Values.juiceShop.securityContext | toJson }},
         "env": {{ .Values.juiceShop.env | toJson }},
-        "envFrom": {{ .Values.juiceShop.envFrom | toJson }}
-        "volumes": {{ .Values.juiceShop.volumes | toJson }}
+        "envFrom": {{ .Values.juiceShop.envFrom | toJson }},
+        "volumes": {{ .Values.juiceShop.volumes | toJson }},
         "volumeMounts": {{ .Values.juiceShop.volumeMounts | toJson }}
       }
     }

--- a/helm/multi-juicer/values.yaml
+++ b/helm/multi-juicer/values.yaml
@@ -123,14 +123,19 @@ juiceShop:
   envFrom: []
   # juiceShop.volumes -- Optional Volumes to set for each JuiceShop instance (see: https://kubernetes.io/docs/concepts/storage/volumes/)
   volumes: []
-  #volumes: 
-  #  - name: my-extra-volume
-  #   mountPath: /var/lib/juice-shop
+  # create config map with a custom logo via: kubectl create configmap custom-logo --from-file custom.png=your-logo.png
+  # then switch out the logo parameter in the juice-shop config section above to the mounted filename.
+  # volumes: 
+  # - name: logo
+  #   configMap:
+  #     name: custom-logo
   # juiceShop.volumeMounts -- Optional VolumeMounts to set for each JuiceShop instance (see: https://kubernetes.io/docs/concepts/storage/volumes/)
   volumeMounts: []
-  #volumeMounts:
-  #  - name: my-extra-volume
-  #    emptyDir: {}
+  # volumeMounts:
+  # - name: logo
+  #   mountPath: /juice-shop/frontend/dist/frontend/assets/public/images/custom.png
+  #   subPath: custom.png
+  #   readOnly: true
 
 # Deletes unused JuiceShop instances after a configurable period of inactivity
 progressWatchdog:

--- a/helm/multi-juicer/values.yaml
+++ b/helm/multi-juicer/values.yaml
@@ -110,7 +110,7 @@ juiceShop:
   #    cpu: 100m
   #    memory: 200Mi
   # juiceShop.securityContext -- Optional securityContext definitions to set for each JuiceShop instance
-  securityContext: []
+  securityContext: {}
   # juiceShop.env -- Optional environment variables to set for each JuiceShop instance (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
   env: []
   # env:

--- a/helm/multi-juicer/values.yaml
+++ b/helm/multi-juicer/values.yaml
@@ -83,8 +83,6 @@ juiceShop:
   tag: v12.3.0
   # juiceShop.ctfKey -- Change the key when hosting a CTF event. This key gets used to generate the challenge flags. See: https://pwning.owasp-juice.shop/part1/ctf.html#overriding-the-ctfkey
   ctfKey: "zLp@.-6fMW6L-7R3b!9uR_K!NfkkTr"
-  resources: {}
-  securityContext: {}
   # Specify a custom Juice Shop config.yaml
   # juiceShop.config -- See the JuiceShop Config Docs for more detail: https://pwning.owasp-juice.shop/part1/customization.html#yaml-configuration-file
   # @default -- See values.yaml for full details
@@ -102,6 +100,37 @@ juiceShop:
       showFlagsInNotifications: false
   # juiceShop.nodeEnv -- Specify a custom NODE_ENV for JuiceShop. If value is changed to something other than 'multi-juicer' it's not possible to set a custom config via `juiceShop.config`.
   nodeEnv: "multi-juicer"
+  # juiceShop.env -- Optional resources definitions to set for each JuiceShop instance
+  resources: []
+  #resources: 
+  #  limits:
+  #    cpu: 100m
+  #    memory: 200Mi
+  #  requests:
+  #    cpu: 100m
+  #    memory: 200Mi
+  # juiceShop.securityContext -- Optional securityContext definitions to set for each JuiceShop instance
+  securityContext: []
+  # juiceShop.env -- Optional environment variables to set for each JuiceShop instance (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+  env: []
+  # env:
+  #   - name: FOO
+  #     valueFrom:
+  #       secretKeyRef:
+  #         key: FOO
+  #         name: secret-resource
+  # juiceShop.envFrom -- Optional mount environment variables from configMaps or secrets (see: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables)
+  envFrom: []
+  # juiceShop.volumes -- Optional Volumes to set for each JuiceShop instance (see: https://kubernetes.io/docs/concepts/storage/volumes/)
+  volumes: []
+  #volumes: 
+  #  - name: my-extra-volume
+  #   mountPath: /var/lib/juice-shop
+  # juiceShop.volumeMounts -- Optional VolumeMounts to set for each JuiceShop instance (see: https://kubernetes.io/docs/concepts/storage/volumes/)
+  volumeMounts: []
+  #volumeMounts:
+  #  - name: my-extra-volume
+  #    emptyDir: {}
 
 # Deletes unused JuiceShop instances after a configurable period of inactivity
 progressWatchdog:

--- a/helm/multi-juicer/values.yaml
+++ b/helm/multi-juicer/values.yaml
@@ -100,7 +100,7 @@ juiceShop:
       showFlagsInNotifications: false
   # juiceShop.nodeEnv -- Specify a custom NODE_ENV for JuiceShop. If value is changed to something other than 'multi-juicer' it's not possible to set a custom config via `juiceShop.config`.
   nodeEnv: "multi-juicer"
-  # juiceShop.env -- Optional resources definitions to set for each JuiceShop instance
+  # juiceShop.resources -- Optional resources definitions to set for each JuiceShop instance
   resources: []
   #resources: 
   #  limits:

--- a/juice-balancer/src/config.js
+++ b/juice-balancer/src/config.js
@@ -2,13 +2,13 @@ const config = require('../config/config.json');
 const lodashGet = require('lodash/get');
 const memoize = require('lodash/memoize');
 
-const fetchConfigValue = (name) => {
+const fetchConfigValue = (name, defaultValue) => {
   const envVarName = name
     .split('.')
     .map((string) => string.toUpperCase())
     .join('_');
 
-  return process.env[envVarName] || lodashGet(config, name);
+  return process.env[envVarName] || lodashGet(config, name, defaultValue);
 };
 
 const get = memoize(fetchConfigValue);

--- a/juice-balancer/src/kubernetes.js
+++ b/juice-balancer/src/kubernetes.js
@@ -9,7 +9,6 @@ const { get } = require('./config');
 
 const lodashGet = require('lodash/get');
 const once = require('lodash/once');
-const _ = require('lodash');
 
 // Gets the Deployment uid for the JuiceBalancer
 // This is required to set the JuiceBalancer as owner of the created JuiceShop Instances
@@ -70,7 +69,7 @@ const createDeploymentForTeam = async ({ team, passcodeHash }) => {
                   name: 'CTF_KEY',
                   value: get('juiceShop.ctfKey'),
                 },
-                ...(!_.isEmpty(get('juiceShop.env')) && get('juiceShop.env')),
+                ...get('juiceShop.env', []),
               ],
               envFrom: get('juiceShop.envFrom'),
               ports: [
@@ -101,7 +100,7 @@ const createDeploymentForTeam = async ({ team, passcodeHash }) => {
                   mountPath: '/juice-shop/config/multi-juicer.yaml',
                   subPath: 'multi-juicer.yaml',
                 },
-                ...(!_.isEmpty(get('juiceShop.volumeMounts')) && get('juiceShop.volumeMounts')),
+                ...get('juiceShop.volumeMounts', []),
               ],
             },
           ],
@@ -112,7 +111,7 @@ const createDeploymentForTeam = async ({ team, passcodeHash }) => {
                 name: 'juice-shop-config',
               },
             },
-            ...(!_.isEmpty(get('juiceShop.volumes')) && get('juiceShop.volumes')),
+            ...get('juiceShop.volumes', []),
           ],
         },
       },

--- a/juice-balancer/src/kubernetes.js
+++ b/juice-balancer/src/kubernetes.js
@@ -9,6 +9,7 @@ const { get } = require('./config');
 
 const lodashGet = require('lodash/get');
 const once = require('lodash/once');
+const _ = require('lodash');
 
 // Gets the Deployment uid for the JuiceBalancer
 // This is required to set the JuiceBalancer as owner of the created JuiceShop Instances
@@ -69,7 +70,9 @@ const createDeploymentForTeam = async ({ team, passcodeHash }) => {
                   name: 'CTF_KEY',
                   value: get('juiceShop.ctfKey'),
                 },
+                ...(!_.isEmpty(get('juiceShop.env')) && get('juiceShop.env')),
               ],
+              envFrom: get('juiceShop.envFrom'),
               ports: [
                 {
                   containerPort: 3000,
@@ -98,6 +101,7 @@ const createDeploymentForTeam = async ({ team, passcodeHash }) => {
                   mountPath: '/juice-shop/config/multi-juicer.yaml',
                   subPath: 'multi-juicer.yaml',
                 },
+                ...(!_.isEmpty(get('juiceShop.volumeMounts')) && get('juiceShop.volumeMounts')),
               ],
             },
           ],
@@ -108,6 +112,7 @@ const createDeploymentForTeam = async ({ team, passcodeHash }) => {
                 name: 'juice-shop-config',
               },
             },
+            ...(!_.isEmpty(get('juiceShop.volumes')) && get('juiceShop.volumes')),
           ],
         },
       },


### PR DESCRIPTION
This PR if applied will add some additional HelmChart configurations:
- ENV
- Volume
- VolumeMounts 
which can be defined for each JuiceShop instance.

This new option can be used to add additional juiceShop static resources for theming stuff.