### PR TITLE
Add Https Section to Azure Setup Guide

### DIFF
--- a/guides/azure/azure.md
+++ b/guides/azure/azure.md
@@ -81,3 +81,8 @@ spec:
   ```bash
   kubectl create -f loadbalancer.yaml
   ```
+
+## Step 5. SSL
+
+To expose multi-juicer over https you should use a propper ingress controller instead of just a loadbalancer. This will give you far better control. Remove the loadbalancer from step 4 once you have setup the https connection. To continue follow [the multi-juicer azure ssl guide](ssl.md)
+

--- a/guides/azure/ssl.md
+++ b/guides/azure/ssl.md
@@ -4,6 +4,8 @@
 Following this guide, you should be able to setup a https ingress with certificates from letsencrypt. https://docs.microsoft.com/en-us/azure/aks/ingress-tls?tabs=azure-cli .
 This guide is based on the official microsoft guide and tested on azure. 
 
+Please note: Make sure that you haven't setup an ingress already. There is an option for configuring an ingress when installing multi-juicer with your own `values.yaml`. This guide require that you haven't ventured down that path.
+
 ## 1. Create the Container registry 
 
 First create a container registry where you will be storing the images for your cert-manager and nginx controller

--- a/guides/azure/ssl.md
+++ b/guides/azure/ssl.md
@@ -1,0 +1,217 @@
+
+# Setup SSL for multi-juicer with Microsoft Azure
+
+Following this guide, you should be able to setup a https ingress with certificates from letsencrypt. https://docs.microsoft.com/en-us/azure/aks/ingress-tls?tabs=azure-cli
+You might want to use the default namespace instead of creating a new namespace called ingress-basic as outlined in the guide. You won't need the loadbalancer service as outlined in the [multi-juicer azure setup guide](azure.md) if you set up your own ingress. 
+
+## 1. Create the Container registry 
+
+First create a container registry where you will be storing the images for your cert-manager and nginx controller
+
+NB: Please note that you will need to pick a new name for the registry since the name needs to be globally unique.
+
+```bash
+az acr create -n <acr-name> -g multi-juicer --sku basic
+
+```
+
+Then connect the registry with your multi-juicer kubernetes cluster
+
+```bash
+az aks update -n juicy-k8s -g multi-juicer --attach-acr <acr-name>
+```
+
+Import the images for the cert-manager and nginx controller
+
+```bash
+REGISTRY_NAME=<acr-name>
+SOURCE_REGISTRY=k8s.gcr.io
+CONTROLLER_IMAGE=ingress-nginx/controller
+CONTROLLER_TAG=v1.0.4
+PATCH_IMAGE=ingress-nginx/kube-webhook-certgen
+PATCH_TAG=v1.1.1
+DEFAULTBACKEND_IMAGE=defaultbackend-amd64
+DEFAULTBACKEND_TAG=1.5
+CERT_MANAGER_REGISTRY=quay.io
+CERT_MANAGER_TAG=v1.5.4
+CERT_MANAGER_IMAGE_CONTROLLER=jetstack/cert-manager-controller
+CERT_MANAGER_IMAGE_WEBHOOK=jetstack/cert-manager-webhook
+CERT_MANAGER_IMAGE_CAINJECTOR=jetstack/cert-manager-cainjector
+
+az acr import --name $REGISTRY_NAME --source $SOURCE_REGISTRY/$CONTROLLER_IMAGE:$CONTROLLER_TAG --image $CONTROLLER_IMAGE:$CONTROLLER_TAG
+az acr import --name $REGISTRY_NAME --source $SOURCE_REGISTRY/$PATCH_IMAGE:$PATCH_TAG --image $PATCH_IMAGE:$PATCH_TAG
+az acr import --name $REGISTRY_NAME --source $SOURCE_REGISTRY/$DEFAULTBACKEND_IMAGE:$DEFAULTBACKEND_TAG --image $DEFAULTBACKEND_IMAGE:$DEFAULTBACKEND_TAG
+az acr import --name $REGISTRY_NAME --source $CERT_MANAGER_REGISTRY/$CERT_MANAGER_IMAGE_CONTROLLER:$CERT_MANAGER_TAG --image $CERT_MANAGER_IMAGE_CONTROLLER:$CERT_MANAGER_TAG
+az acr import --name $REGISTRY_NAME --source $CERT_MANAGER_REGISTRY/$CERT_MANAGER_IMAGE_WEBHOOK:$CERT_MANAGER_TAG --image $CERT_MANAGER_IMAGE_WEBHOOK:$CERT_MANAGER_TAG
+az acr import --name $REGISTRY_NAME --source $CERT_MANAGER_REGISTRY/$CERT_MANAGER_IMAGE_CAINJECTOR:$CERT_MANAGER_TAG --image $CERT_MANAGER_IMAGE_CAINJECTOR:$CERT_MANAGER_TAG
+
+```
+
+## 2. Create an nginx ingress controller
+
+```bash
+# Add the ingress-nginx repository
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+
+# Set variable for ACR location to use for pulling images
+ACR_URL=<acr-name>.azurecr.io
+
+# Use Helm to deploy an NGINX ingress controller
+helm install nginx-ingress ingress-nginx/ingress-nginx \
+    --version 4.0.13 \
+    --namespace default --create-namespace \
+    --set controller.replicaCount=2 \
+    --set controller.nodeSelector."kubernetes\.io/os"=linux \
+    --set controller.image.registry=$ACR_URL \
+    --set controller.image.image=$CONTROLLER_IMAGE \
+    --set controller.image.tag=$CONTROLLER_TAG \
+    --set controller.image.digest="" \
+    --set controller.admissionWebhooks.patch.nodeSelector."kubernetes\.io/os"=linux \
+    --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-health-probe-request-path"=/healthz \
+    --set controller.admissionWebhooks.patch.image.registry=$ACR_URL \
+    --set controller.admissionWebhooks.patch.image.image=$PATCH_IMAGE \
+    --set controller.admissionWebhooks.patch.image.tag=$PATCH_TAG \
+    --set controller.admissionWebhooks.patch.image.digest="" \
+    --set defaultBackend.nodeSelector."kubernetes\.io/os"=linux \
+    --set defaultBackend.image.registry=$ACR_URL \
+    --set defaultBackend.image.image=$DEFAULTBACKEND_IMAGE \
+    --set defaultBackend.image.tag=$DEFAULTBACKEND_TAG \
+    --set defaultBackend.image.digest=""
+```
+
+## 3. Configure a FQDN
+
+Get the external ip of the controller
+
+```bash
+$ kubectl --namespace default get services -o wide -w nginx-ingress-ingress-nginx-controller
+
+NAME                                     TYPE           CLUSTER-IP    EXTERNAL-IP     PORT(S)                      AGE   SELECTOR
+nginx-ingress-ingress-nginx-controller   LoadBalancer   10.0.74.133   EXTERNAL_IP     80:32486/TCP,443:30953/TCP   44s   app.kubernetes.io/component=controller,app.kubernetes.io/instance=nginx-ingress,app.kubernetes.io/name=ingress-nginx
+```
+
+Configure a FQDN for your external ip. The DNS has to be unique
+
+NB: See this guide if you have your own domain: https://docs.microsoft.com/en-us/azure/aks/ingress-tls?tabs=azure-cli#add-an-a-record-to-your-dns-zone
+
+```bash
+
+# Public IP address of your ingress controller
+IP="MY_EXTERNAL_IP"
+
+# Name to associate with public IP address
+DNSNAME="my-multi-juicer"
+
+# Get the resource-id of the public ip
+PUBLICIPID=$(az network public-ip list --query "[?ipAddress!=null]|[?contains(ipAddress, '$IP')].[id]" --output tsv)
+
+# Update public ip address with DNS name
+az network public-ip update --ids $PUBLICIPID --dns-name $DNSNAME
+
+```
+
+## 4. Install the cert-manager
+
+```bash
+# Label the default namespace to disable resource validation
+kubectl label namespace default cert-manager.io/disable-validation=true
+
+# Add the Jetstack Helm repository
+helm repo add jetstack https://charts.jetstack.io
+
+# Update your local Helm chart repository cache
+helm repo update
+
+# Install the cert-manager Helm chart
+helm install cert-manager jetstack/cert-manager \
+  --namespace default \
+  --version $CERT_MANAGER_TAG \
+  --set installCRDs=true \
+  --set nodeSelector."kubernetes\.io/os"=linux \
+  --set image.repository=$ACR_URL/$CERT_MANAGER_IMAGE_CONTROLLER \
+  --set image.tag=$CERT_MANAGER_TAG \
+  --set webhook.image.repository=$ACR_URL/$CERT_MANAGER_IMAGE_WEBHOOK \
+  --set webhook.image.tag=$CERT_MANAGER_TAG \
+  --set cainjector.image.repository=$ACR_URL/$CERT_MANAGER_IMAGE_CAINJECTOR \
+  --set cainjector.image.tag=$CERT_MANAGER_TAG
+```
+## 5. Create a cluster issuer
+
+Save the following content as `cluster-issuer.yaml`
+```bash
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: MY_EMAIL_ADDRESS
+    privateKeySecretRef:
+      name: letsencrypt
+    solvers:
+    - http01:
+        ingress:
+          class: nginx
+          podTemplate:
+            spec:
+              nodeSelector:
+                "kubernetes.io/os": linux
+```
+To create the issuer, use the kubectl apply command.
+```bash
+kubectl apply -f cluster-issuer.yaml
+```
+
+## 6. Create an ingress route
+
+Save the following content as `ingress.yaml`
+
+```bash
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: my-multi-juicer
+  annotations: 
+    cert-manager.io/cluster-issuer: letsencrypt
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - my-multi-juicer.<availability zone>.cloudapp.azure.com
+    secretName: tls-secret
+  rules:
+  - host: my-multi-juicer.<availability zone>.cloudapp.azure.com
+    http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: juice-balancer
+            port:
+              number: 3000
+```
+Edit the host so that it corresponds to the host associated with your public ip. You find the hostname of your public ip by executing this command.
+
+```bash
+az network public-ip show --ids $PUBLICIPID --query "[dnsSettings.fqdn]" --output tsv
+```
+
+
+Create the ingress route
+
+```bash
+kubectl apply -f ingress.yaml --namespace default
+```
+
+Verify that the a certificate has been assigned. NB: can take several minutes.
+
+```bash
+$ kubectl get certificate --namespace default
+
+NAME         READY   SECRET       AGE
+tls-secret   True    tls-secret   11m
+```
+Test that the ingress is working by opening a browser and trying the host address. Make sure that you use https
+

--- a/guides/azure/ssl.md
+++ b/guides/azure/ssl.md
@@ -1,8 +1,8 @@
 
 # Setup SSL for multi-juicer with Microsoft Azure
 
-Following this guide, you should be able to setup a https ingress with certificates from letsencrypt. https://docs.microsoft.com/en-us/azure/aks/ingress-tls?tabs=azure-cli
-You might want to use the default namespace instead of creating a new namespace called ingress-basic as outlined in the guide. You won't need the loadbalancer service as outlined in the [multi-juicer azure setup guide](azure.md) if you set up your own ingress. 
+Following this guide, you should be able to setup a https ingress with certificates from letsencrypt. https://docs.microsoft.com/en-us/azure/aks/ingress-tls?tabs=azure-cli .
+This guide is based on the official microsoft guide and tested on azure. 
 
 ## 1. Create the Container registry 
 


### PR DESCRIPTION
I have added a guide for how to setup ssl for multi-juicer using a nginx kubernetes controller.
I saw that there already was an option for setting up ssl by applying the proper configuration to `values.yaml` during the installation of multi-juicer, but I found it quite hard to setup this for someone like me with limited kubernetes knowledge. 
There are too many options that you need to take into account and I think it would be better to just have a very simple and straightforward guide on how to do this so that the user doesn't get lost.