### PR TITLE
Fix/image links in helm readme

### DIFF
--- a/helm/multi-juicer/README.md
+++ b/helm/multi-juicer/README.md
@@ -12,7 +12,7 @@ MultiJuicer gives you the ability to run separate Juice Shop instances for every
 - backup and auto apply challenge progress in case of Juice Shop container restarts
 - cleanup old & unused instances automatically
 
-![MultiJuicer, High Level Architecture Diagram](https://raw.githubusercontent.com/iteratec/multi-juicer/main/high-level-architecture.svg)
+![MultiJuicer, High Level Architecture Diagram](https://raw.githubusercontent.com/iteratec/multi-juicer/main/images/high-level-architecture.svg)
 
 ## Configuration
 

--- a/helm/multi-juicer/README.md.gotmpl
+++ b/helm/multi-juicer/README.md.gotmpl
@@ -12,7 +12,7 @@ MultiJuicer gives you the ability to run separate Juice Shop instances for every
 - backup and auto apply challenge progress in case of Juice Shop container restarts
 - cleanup old & unused instances automatically
 
-![MultiJuicer, High Level Architecture Diagram](https://raw.githubusercontent.com/iteratec/multi-juicer/main/high-level-architecture.svg)
+![MultiJuicer, High Level Architecture Diagram](https://raw.githubusercontent.com/iteratec/multi-juicer/main/images/high-level-architecture.svg)
 
 ## Configuration
 


### PR DESCRIPTION
Fix broken links in both the `Readme.md` and `README.md.gotmpl` for the high level architecture overview.