### PR TITLE
Improve Digital Ocean guide

### DIFF
--- a/guides/digital-ocean/digital-ocean.md
+++ b/guides/digital-ocean/digital-ocean.md
@@ -38,6 +38,14 @@ kubectl get pods
 # Wait until both pods are ready
 ```
 
+If the juice-balancer pod is still pending status after a couple of minutes, the cluster may not have the necessary resources to provision the pod.
+
+```bash
+# This show details about the juice-balancer pod. Warnings can be found under Events, and the cluster 
+# does not have the necessary resources if theres is a warning about insufficient CPU or memory.
+kubectl describe pods juice-balancer
+```
+
 ## Step 3. Verify the app is running correctly
 
 This step is optional, but helpful to catch errors quicker.

--- a/guides/digital-ocean/do-lb.yaml
+++ b/guides/digital-ocean/do-lb.yaml
@@ -13,10 +13,14 @@ metadata:
 spec:
   type: LoadBalancer
   selector:
-    app.kubernetes.io/instance: multi-juicer
-    app.kubernetes.io/name: multi-juicer
+    app.kubernetes.io/instance: juice-balancer-multi-juicer
+    app.kubernetes.io/name: juice-balancer
   ports:
     - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 3000
+    - name: https
       protocol: TCP
       port: 443
       targetPort: 3000


### PR DESCRIPTION
I ran trough the Digital Ocean guide and faced some problems. I got the cluster up and running after som troubleshooting, and I want to share how I did it.

The changes introduced with this PR are:

1. Updated selectors so the load balancer can reach the juice-balancer pod.
2. Added a HTTP listener to enable HTTP to HTTPS redirect.
3. Added some instructions on how to troubleshoot when the juice-balancer pod hangs on pending.

# Problem 1: Provisioning the cluster

When installing multi-juicer on the cluster the juice-blancer pod is stuck on pending when I run `kubectl get pods`. I got the following message when I described the pod:

```
Warning  FailedScheduling   7m18s                default-scheduler   0/3 nodes are available: 3 Insufficient cpu. preemption: 0/3 nodes are available: 3 No preemption victims found for incoming pod..
```

The default node size is `s-1vcpu-2g`. I worked when I upgraded to `s-2vcpu-2g`. The downside is a more expensive cluster, approximately $66 per month.

# Problem 2:

When provisioning the load balancer in step 4, I got this warning.

```
Warning  SyncLoadBalancerFailed  4m4s                service-controller  Error syncing load balancer: failed to ensure load balancer: load-balancer is not yet active (current status: new)
```

The provisioned load balancer can't reach juice-balancer. I get the following labels when I describe the juice-balancer pod.

```
Labels:       app.kubernetes.io/component=load-balancer
              app.kubernetes.io/instance=juice-balancer-multi-juicer
              app.kubernetes.io/managed-by=Helm
              app.kubernetes.io/name=juice-balancer
              app.kubernetes.io/part-of=multi-juicer
              app.kubernetes.io/version=5.3.0
              pod-template-hash=b756f7b9c
```

When I updated the selector, the load balancer provisioned as expected.