### PR TITLE
Fix typos in documentation and helm chart

### DIFF
--- a/guides/aws/aws.md
+++ b/guides/aws/aws.md
@@ -113,7 +113,7 @@ kubectl get pods -n kube-system
 helm delete multi-juicer
 
 # Delete the loadbalancer setup
-kubectl delete -f kubectl create -f  https://raw.githubusercontent.com/iteratec/multi-juicer/main/guides/aws/loadbalancer.yaml
+kubectl delete -f https://raw.githubusercontent.com/iteratec/multi-juicer/main/guides/aws/loadbalancer.yaml
 
 # Delete the kubernetes cluster
 eksctl delete cluster multi-juicer

--- a/helm/multi-juicer/templates/juice-balancer/secret.yaml
+++ b/helm/multi-juicer/templates/juice-balancer/secret.yaml
@@ -6,8 +6,8 @@ metadata:
     {{- include "multi-juicer.juice-balancer.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- if .Values.balancer.cookieParserSecret }}
-  cookieParserSecret: {{ .Values.balancer.cookieParserSecret | b64enc | quote }}
+  {{- if .Values.balancer.cookie.cookieParserSecret }}
+  cookieParserSecret: {{ .Values.balancer.cookie.cookieParserSecret | b64enc | quote }}
   {{- else }}
   cookieParserSecret: {{ randAlphaNum 24 | b64enc | quote }}
   {{- end }}

--- a/helm/multi-juicer/values.yaml
+++ b/helm/multi-juicer/values.yaml
@@ -105,7 +105,7 @@ juiceShop:
   resources:
     requests:
       cpu: 150m
-      memory: 200Mi
+      memory: 300Mi
   #  limits:
   #    cpu: 100m
   #    memory: 200Mi

--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,7 @@ You can list all JuiceShops with relevant information using the custom-columns f
 You'll need to down load the juiceShop.txt from the repository first:
 
 ```bash
-kubectl get -l app=juice-shop -o custom-columns-file=juiceShop.txt deployments
+kubectl get -l app.kubernetes.io/name=juice-shop -o custom-columns-file=juiceShop.txt deployments
 ```
 
 ### Did somebody actually ask any of these questions?

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ helm delete multi-juicer
 To be on the safe side calculate with:
 
 - _1GB memory & 1CPU overhead_, for the balancer & co
-- _200MB & 0.2CPU \* number of participants_, for the individual JuiceShop Instances
+- _300MB & 0.2CPU \* number of participants_, for the individual JuiceShop Instances
 
 The numbers above reflect the default resource limits. These can be tweaked, see: [Customizing the Setup](#customizing-the-setup)
 


### PR DESCRIPTION
The PR is a mix of several different minor issues (I can split those into separate parts if necessary). Besides the minor typos, the PR contains two noteworthy changes:

- The helm chart used the wrong key for `cookieParserSecret`, such that setting the value in values.yaml had no effect. I've opted to change the referenced key instead of moving the `cookieParserSecret` around in values.yaml, as this might be more backwards compatible.
- Juiceshop instances by now require at least 260MB RAM (at least when using a VM with 8GB RAM), which has to be considered for capacity planing.