### PR TITLE
Fix duplicate type definition

### DIFF
--- a/helm/multi-juicer/dashboards/instances.json
+++ b/helm/multi-juicer/dashboards/instances.json
@@ -1152,7 +1152,7 @@
           "valueName": "current"
         }
       ],
-      "title": "Buisiness Metrics",
+      "title": "Business Metrics",
       "type": "row"
     },
     {

--- a/helm/multi-juicer/templates/juice-balancer/service.yaml
+++ b/helm/multi-juicer/templates/juice-balancer/service.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "multi-juicer.juice-balancer.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.balancer.service.type }}
 {{- if (or (eq .Values.balancer.service.type "ClusterIP") (empty .Values.balancer.service.type)) }}
   type: ClusterIP
   {{- if .Values.balancer.service.clusterIP }}

--- a/helm/multi-juicer/values.yaml
+++ b/helm/multi-juicer/values.yaml
@@ -32,7 +32,7 @@ balancer:
     secure: false
     # -- Changes the cookies name used to identify teams. Note will automatically be prefixed with "__Secure-" when balancer.cookie.secure is set to `true`
     name: balancer
-    # -- Set this to a fixed random alpa-numeric string (recommended length 24 chars). If not set this get randomly generated with every helm upgrade, each rotation invalidates all active cookies / sessions requirering users to login again.
+    # -- Set this to a fixed random alpha-numeric string (recommended length 24 chars). If not set this gets randomly generated with every helm upgrade, each rotation invalidates all active cookies / sessions requiring users to login again.
     cookieParserSecret: null
   repository: iteratec/juice-balancer
   tag: null


### PR DESCRIPTION
When using the chart in combination with kustomize (e.g. as part of a Flux setup), its parser complains about a duplicate `type` definition:

```
{"HelmRelease":{…}, "controller":"helmrelease", "controllerGroup":"helm.toolkit.fluxcd.io", "controllerKind":"HelmRelease",
  "error":"Helm install failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
  line 17: mapping key "type" already defined at line 16", "level":"error", "msg":"Reconciler error", "name":"multi-juicer",
  "namespace":"namespace", "reconcileID":"e239b791-71e3-4e94-9ba1-457316e43e55", "ts":"2023-05-15T07:35:19.574Z"}
```

I've also fixed some minor typos in comments on the way.